### PR TITLE
Adds matomo snippet and cookie banner

### DIFF
--- a/docs/javascripts/consent.js
+++ b/docs/javascripts/consent.js
@@ -1,0 +1,15 @@
+document$.subscribe(function() {
+  var consent = __md_get("__consent")
+  if (consent && consent.matomo) {
+    var _paq = window._paq = window._paq || [];
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://matomo.sib.swiss/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '220']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  }
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,6 @@ theme:
   name: material
   logo: assets/images/SIB_logo.svg
   favicon: assets/images/SIB_logo.svg
-  custom_dir: overrides
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,13 @@ theme:
   name: material
   logo: assets/images/SIB_logo.svg
   favicon: assets/images/SIB_logo.svg
+  custom_dir: overrides
 
 extra_css:
   - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/consent.js
 
 markdown_extensions:
   - abbr
@@ -50,5 +54,17 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+
+extra:
+  consent:
+    title: Cookie consent
+    description: >- 
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our trainig material and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our training material better.
+    cookies:
+      matomo: Matomo Analytics


### PR DESCRIPTION
This dynamically adds the matomo snippet after accepting the cookie banner. By doing this, we can track visits at matomo.sib.swiss. 

Note that i also updated the name of the emoji plugin. 